### PR TITLE
[Fix] Gain total audio focus on Bitmovin play

### DIFF
--- a/android/app/src/main/java/com/rohtvapp/ROHBitMovinPlayerPackage/ROHBitMovinPlayerModule.java
+++ b/android/app/src/main/java/com/rohtvapp/ROHBitMovinPlayerPackage/ROHBitMovinPlayerModule.java
@@ -1,6 +1,9 @@
 
 package com.rohtvapp.ROHBitMovinPlayerPackage;
 
+import android.media.AudioManager;
+import android.content.Context;
+
 import android.view.View;
 
 import com.bitmovin.player.PlayerView;
@@ -29,6 +32,9 @@ public class ROHBitMovinPlayerModule extends ReactContextBaseJavaModule {
     View playerContainerView = getCurrentActivity().findViewById(tag);
     if (playerContainerView instanceof PlayerContainerView) {
       if (((PlayerContainerView) playerContainerView).getPlayerView().getPlayer().getCurrentTime() < ((PlayerContainerView) playerContainerView).getPlayerView().getPlayer().getDuration()) {
+        AudioManager audioManager = (AudioManager) this._reactContext.getSystemService(Context.AUDIO_SERVICE);
+        audioManager.requestAudioFocus(null, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
+
         ((PlayerContainerView) playerContainerView).getPlayerView().getPlayer().play();
       }
     } else {

--- a/android/app/src/main/java/com/rohtvapp/ROHBitMovinPlayerPackage/ROHBitMovinPlayerModule.java
+++ b/android/app/src/main/java/com/rohtvapp/ROHBitMovinPlayerPackage/ROHBitMovinPlayerModule.java
@@ -22,6 +22,20 @@ public class ROHBitMovinPlayerModule extends ReactContextBaseJavaModule {
     _reactContext = reactContext;
   }
 
+  private void gainAudioFocus() {
+    AudioManager audioManager = (AudioManager) this._reactContext.getSystemService(Context.AUDIO_SERVICE);
+    audioManager.requestAudioFocus(
+      null,
+      AudioManager.STREAM_MUSIC,
+      AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
+    );
+  }
+
+  private void releaseAudioFocus() {
+    AudioManager audioManager = (AudioManager) this._reactContext.getSystemService(Context.AUDIO_SERVICE);
+    audioManager.abandonAudioFocus(null);
+  }
+
   @Override
   public String getName() {
     return "ROHBitMovinPlayerControl";
@@ -32,10 +46,8 @@ public class ROHBitMovinPlayerModule extends ReactContextBaseJavaModule {
     View playerContainerView = getCurrentActivity().findViewById(tag);
     if (playerContainerView instanceof PlayerContainerView) {
       if (((PlayerContainerView) playerContainerView).getPlayerView().getPlayer().getCurrentTime() < ((PlayerContainerView) playerContainerView).getPlayerView().getPlayer().getDuration()) {
-        AudioManager audioManager = (AudioManager) this._reactContext.getSystemService(Context.AUDIO_SERVICE);
-        audioManager.requestAudioFocus(null, AudioManager.STREAM_MUSIC, AudioManager.AUDIOFOCUS_GAIN);
-
         ((PlayerContainerView) playerContainerView).getPlayerView().getPlayer().play();
+        this.gainAudioFocus();
       }
     } else {
       throw new ClassCastException(String.format("Cannot play: view with tag #%d is not a ROHBitMovinPlayer", tag));
@@ -48,6 +60,7 @@ public class ROHBitMovinPlayerModule extends ReactContextBaseJavaModule {
 
     if (playerContainerView instanceof PlayerContainerView) {
       ((PlayerContainerView) playerContainerView).getPlayerView().getPlayer().pause();
+      this.releaseAudioFocus();
     } else {
       throw new ClassCastException(String.format("Cannot pause: view with tag #%d is not a ROHBitMovinPlayer", tag));
     }


### PR DESCRIPTION
# Context
The reason why this issue was difficult to solve was because we were thinking about it the wrong way. What we had do wasn't to manipulate the **background app's event's** such that the audio does not overlap, but, rather, to **make our app request total control from the current audio track**, so that other apps can't use it.

# Solution
Since native apps have direct access to peripherals, such as speakers, mics, etc..., it means that we're able to manipulate their behaviours from the native modules. As such, requesting the audio device from the application context, casting it to an `AudioManager` and requesting total audio focus from said device did the trick.

# Docs that helped
https://developer.android.com/reference/android/media/AudioManager#requestAudioFocus(android.media.AudioFocusRequest
https://developer.android.com/reference/android/media/AudioManager#AUDIOFOCUS_GAIN

# EDIT
I've updated the logic such that it gains audio focus on video play and releases audio focus on video pause. This works, however, audio focus is not released until the app's video player is unmounted (i.e. you have to exit the video altogether for the focus to be released). I can't figure out why `abandonAudioFocus` does not work.

Nonetheless, this fixes audio overlapping altogether. We just need to figure our a better way to release the focus...