### PR TITLE
fix: Use MediaFilter.Strict and disable tunnelled playback

### DIFF
--- a/android/app/src/main/java/com/rohtvapp/ROHBitMovinPlayerPackage/PlayerContainerView.java
+++ b/android/app/src/main/java/com/rohtvapp/ROHBitMovinPlayerPackage/PlayerContainerView.java
@@ -96,10 +96,10 @@ public class PlayerContainerView extends RelativeLayout {
             true,
             videoCodecPriority,
             audioCodecPriority,
-            true,
+            false,
             SeekMode.Exact,
             null,
-            MediaFilter.Loose,
+            MediaFilter.Strict,
             MediaFilter.Loose
         );
         //playbackConfig.setTunneledPlaybackEnabled(true);


### PR DESCRIPTION
# Audio Filter - MediaFilter.Strict
With this, we can tell Bitmovin to use audio tracks that **work**, rather than **potentially work**.

# Disabling tunnelled playback
According to the [Bitmovin docs](https://cdn.bitmovin.com/player/android/3/docs/-player%20-module/com.bitmovin.player.api/-playback-config/is-tunneled-playback-enabled.html?query=var%20isTunneledPlaybackEnabled:%20Boolean%20=%20false):
> Default value is false.

# Notes
I've experimented with those on my Chromecast and there were no visible changes - every worked fine, as expected. Haven't tested on other devices, so I don't know how it will behave on those.