### PR TITLE
Static highlight rails

### DIFF
--- a/src/components/EventListComponents/components/DigitalEventItem.tsx
+++ b/src/components/EventListComponents/components/DigitalEventItem.tsx
@@ -31,6 +31,7 @@ import {
 import RohImage from '@components/RohImage';
 type DigitalEventItemProps = {
   event: TEventContainer;
+  eventIndex: number;
   canMoveUp?: boolean;
   canMoveDown?: boolean;
   sectionIndex: number;
@@ -63,6 +64,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
   (
     {
       event,
+      eventIndex,
       canMoveUp,
       hasTVPreferredFocus,
       canMoveRight = true,
@@ -128,7 +130,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
           touchableRef.current?.getRef?.().current,
         );
       }
-      ref?.current?.setDigitalEvent(event, eventGroupTitle);
+      ref?.current?.setDigitalEvent(event, eventIndex, eventGroupTitle);
       if (typeof onFocus === 'function') {
         onFocus(touchableRef.current?.getRef?.().current);
       }

--- a/src/components/EventListComponents/components/DigitalEventItem.tsx
+++ b/src/components/EventListComponents/components/DigitalEventItem.tsx
@@ -130,7 +130,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
           touchableRef.current?.getRef?.().current,
         );
       }
-      ref?.current?.setDigitalEvent(event, eventIndex, eventGroupTitle);
+      ref?.current?.setDigitalEvent(event, eventGroupTitle);
       if (typeof onFocus === 'function') {
         onFocus?.({ eventIndex });
       }

--- a/src/components/EventListComponents/components/DigitalEventItem.tsx
+++ b/src/components/EventListComponents/components/DigitalEventItem.tsx
@@ -38,7 +38,7 @@ type DigitalEventItemProps = {
   hasTVPreferredFocus?: boolean;
   canMoveRight?: boolean;
   continueWatching?: boolean;
-  onFocus?: (...[]: any[]) => void;
+  onFocus?: ({ eventIndex }: { eventIndex: number }) => void;
   screenNameFrom: TContentScreenReverseNamesOfNavToDetails;
   eventGroupTitle?: string;
   selectedItemIndex?: number;
@@ -132,7 +132,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
       }
       ref?.current?.setDigitalEvent(event, eventIndex, eventGroupTitle);
       if (typeof onFocus === 'function') {
-        onFocus(touchableRef.current?.getRef?.().current);
+        onFocus?.({ eventIndex });
       }
     };
 

--- a/src/components/EventListComponents/components/DigitalEventItem.tsx
+++ b/src/components/EventListComponents/components/DigitalEventItem.tsx
@@ -132,7 +132,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
       }
       ref?.current?.setDigitalEvent(event, eventGroupTitle);
       if (typeof onFocus === 'function') {
-        onFocus?.({ selectedEventIndex: eventIndex });
+        onFocus({ selectedEventIndex: eventIndex });
       }
     };
 

--- a/src/components/EventListComponents/components/DigitalEventItem.tsx
+++ b/src/components/EventListComponents/components/DigitalEventItem.tsx
@@ -38,7 +38,7 @@ type DigitalEventItemProps = {
   hasTVPreferredFocus?: boolean;
   canMoveRight?: boolean;
   continueWatching?: boolean;
-  onFocus?: ({ eventIndex }: { eventIndex: number }) => void;
+  onFocus?: ({ selectedEventIndex }: { selectedEventIndex: number }) => void;
   screenNameFrom: TContentScreenReverseNamesOfNavToDetails;
   eventGroupTitle?: string;
   selectedItemIndex?: number;
@@ -132,7 +132,7 @@ const DigitalEventItem = forwardRef<any, DigitalEventItemProps>(
       }
       ref?.current?.setDigitalEvent(event, eventGroupTitle);
       if (typeof onFocus === 'function') {
-        onFocus?.({ eventIndex });
+        onFocus?.({ selectedEventIndex: eventIndex });
       }
     };
 

--- a/src/components/EventListComponents/components/Preview.tsx
+++ b/src/components/EventListComponents/components/Preview.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   forwardRef,
   useLayoutEffect,
+  useCallback,
 } from 'react';
 import { View, StyleSheet, Animated } from 'react-native';
 import { scaleSize } from '@utils/scaleSize';
@@ -16,8 +17,10 @@ import { OverflowingContainer } from '@components/OverflowingContainer';
 import RohImage from 'components/RohImage';
 
 export type TPreviewRef = {
+  index: number;
   setDigitalEvent?: (
     digitalEvent: TEventContainer,
+    itemIndexInRail?: number,
     eveGroupTitle?: string,
   ) => void;
   setShowContinueWatching?: (showContinueWatching: boolean) => void;
@@ -29,22 +32,32 @@ const Preview = forwardRef<TPreviewRef, TPreviewProps>((props, ref) => {
   const fadeAnimation = useRef<Animated.Value>(new Animated.Value(0)).current;
   const mountedRef = useRef<boolean>(false);
   const [event, setEvent] = useState<TEvent | null>(null);
+
+  const [index, setIndex] = useState<number>(0);
+
   const [eventGroupTitle, setEventGroupTitle] = useState<string>('');
-  useImperativeHandle(
-    ref,
-    () => ({
-      setDigitalEvent: (
-        digitalEvent: TEventContainer,
-        eveGroupTitle: string = '',
-      ) => {
-        if (mountedRef.current) {
-          setEvent(digitalEvent.data);
-          setEventGroupTitle(eveGroupTitle);
-        }
-      },
-    }),
+
+  const setDigitalEvent = useCallback(
+    (
+      digitalEvent: TEventContainer,
+      itemIndexInRail: number = 0,
+      eveGroupTitle: string = '',
+    ) => {
+      if (mountedRef.current) {
+        console.log({
+          data: digitalEvent.data.vs_title[0].text,
+          itemIndexInRail,
+          eveGroupTitle: eveGroupTitle,
+        });
+        setEvent(digitalEvent.data);
+        setIndex(itemIndexInRail);
+        setEventGroupTitle(eveGroupTitle);
+      }
+    },
     [],
   );
+
+  useImperativeHandle(ref, () => ({ index, setDigitalEvent }), [index, setDigitalEvent]);
 
   const eventTitle: string =
     get(event, ['vs_title', '0', 'text'], '').replace(/(<([^>]+)>)/gi, '') ||

--- a/src/components/EventListComponents/components/Preview.tsx
+++ b/src/components/EventListComponents/components/Preview.tsx
@@ -17,10 +17,8 @@ import { OverflowingContainer } from '@components/OverflowingContainer';
 import RohImage from 'components/RohImage';
 
 export type TPreviewRef = {
-  index: number;
   setDigitalEvent?: (
     digitalEvent: TEventContainer,
-    itemIndexInRail?: number,
     eveGroupTitle?: string,
   ) => void;
   setShowContinueWatching?: (showContinueWatching: boolean) => void;
@@ -32,32 +30,23 @@ const Preview = forwardRef<TPreviewRef, TPreviewProps>((props, ref) => {
   const fadeAnimation = useRef<Animated.Value>(new Animated.Value(0)).current;
   const mountedRef = useRef<boolean>(false);
   const [event, setEvent] = useState<TEvent | null>(null);
-
-  const [index, setIndex] = useState<number>(0);
-
   const [eventGroupTitle, setEventGroupTitle] = useState<string>('');
 
-  const setDigitalEvent = useCallback(
-    (
-      digitalEvent: TEventContainer,
-      itemIndexInRail: number = 0,
-      eveGroupTitle: string = '',
-    ) => {
-      if (mountedRef.current) {
-        console.log({
-          data: digitalEvent.data.vs_title[0].text,
-          itemIndexInRail,
-          eveGroupTitle: eveGroupTitle,
-        });
-        setEvent(digitalEvent.data);
-        setIndex(itemIndexInRail);
-        setEventGroupTitle(eveGroupTitle);
-      }
-    },
+  useImperativeHandle(
+    ref,
+    () => ({
+      setDigitalEvent: (
+        digitalEvent: TEventContainer,
+        eveGroupTitle: string = '',
+      ) => {
+        if (mountedRef.current) {
+          setEvent(digitalEvent.data);
+          setEventGroupTitle(eveGroupTitle);
+        }
+      },
+    }),
     [],
   );
-
-  useImperativeHandle(ref, () => ({ index, setDigitalEvent }), [index, setDigitalEvent]);
 
   const eventTitle: string =
     get(event, ['vs_title', '0', 'text'], '').replace(/(<([^>]+)>)/gi, '') ||

--- a/src/components/EventListComponents/components/Preview.tsx
+++ b/src/components/EventListComponents/components/Preview.tsx
@@ -30,7 +30,6 @@ const Preview = forwardRef<TPreviewRef, TPreviewProps>((props, ref) => {
   const mountedRef = useRef<boolean>(false);
   const [event, setEvent] = useState<TEvent | null>(null);
   const [eventGroupTitle, setEventGroupTitle] = useState<string>('');
-
   useImperativeHandle(
     ref,
     () => ({

--- a/src/components/EventListComponents/components/Preview.tsx
+++ b/src/components/EventListComponents/components/Preview.tsx
@@ -4,7 +4,6 @@ import React, {
   useRef,
   forwardRef,
   useLayoutEffect,
-  useCallback,
 } from 'react';
 import { View, StyleSheet, Animated } from 'react-native';
 import { scaleSize } from '@utils/scaleSize';

--- a/src/components/EventListComponents/components/RailSections.tsx
+++ b/src/components/EventListComponents/components/RailSections.tsx
@@ -61,6 +61,7 @@ const RailSections: React.FC<TRailSectionsProps> = props => {
   const scrollToTop = useRef<boolean>(false);
   const scrollToBottom = useRef<boolean>(false);
   const railItemsListRef = useRef<VirtualizedList<any> | null>(null);
+  const railCollection = useRef<(VirtualizedList<any> | null)[]>([]);
   const railsItemsNodesRef = useRef<{
     [key: string]: string;
   }>({});
@@ -159,6 +160,7 @@ const RailSections: React.FC<TRailSectionsProps> = props => {
         index,
       });
     }
+    return railCollection.current[index];
   };
 
   useFocusEffect(
@@ -260,9 +262,14 @@ const RailSections: React.FC<TRailSectionsProps> = props => {
               initialNumToRender={sectionItemsInitialNumber}
               getItem={(data, index) => data[index]}
               data={sectionItem.data}
-              ref={
-                sectionItemIndex === sectionIndex ? railItemsListRef : undefined
-              }
+              ref={component => {
+                railCollection.current[sectionItemIndex] = component;
+
+                if (sectionItemIndex !== sectionIndex) {
+                  return;
+                }
+                railItemsListRef.current = component;
+              }}
               keyExtractor={(sectionItemForKeyExtracting: any) =>
                 sectionItemKeyExtractor(sectionItemForKeyExtracting)
               }

--- a/src/components/EventListComponents/components/RailSections.tsx
+++ b/src/components/EventListComponents/components/RailSections.tsx
@@ -6,6 +6,7 @@ import React, {
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
+  useEffect,
 } from 'react';
 import {
   View,
@@ -23,6 +24,7 @@ import { TVEventManager } from '@services/tvRCEventListener';
 import debounce from 'lodash.debounce';
 
 type TRailSectionsProps = {
+  horizontalRailOffset: number;
   containerStyle?: ViewProps['style'];
   sections: Array<{ [key: string]: any }>;
   sectionKeyExtractor?: (data: { [key: string]: any }) => string;
@@ -40,6 +42,7 @@ type TRailSectionsProps = {
 
 const RailSections: React.FC<TRailSectionsProps> = props => {
   const {
+    horizontalRailOffset,
     containerStyle = {},
     sections,
     sectionKeyExtractor = data => data.id,
@@ -209,6 +212,16 @@ const RailSections: React.FC<TRailSectionsProps> = props => {
       };
     }, []),
   );
+
+  useEffect(() => {
+    if (mountedRef.current) {
+      railItemsListRef.current?.scrollToOffset({
+        animated: true,
+        offset: horizontalRailOffset * 187.5,
+      });
+    }
+  }, [horizontalRailOffset]);
+
   return (
     <View style={[containerStyle]}>
       <VirtualizedList
@@ -299,7 +312,7 @@ const RailSections: React.FC<TRailSectionsProps> = props => {
                   isLastRail: sections.length - 1 === sectionItemIndex,
                   setRailItemRefCb: setRailItemRef,
                   removeRailItemRefCb: removeRailItemRef,
-                  hasEndlessScroll: sections.length > 2,
+                  hasEndlessScroll: sections.length > 1,
                 });
               }}
             />

--- a/src/components/EventListComponents/components/RailSections.tsx
+++ b/src/components/EventListComponents/components/RailSections.tsx
@@ -308,7 +308,7 @@ const RailSections: React.FC<TRailSectionsProps> = props => {
                   isLastRail: sections.length - 1 === sectionItemIndex,
                   setRailItemRefCb: setRailItemRef,
                   removeRailItemRefCb: removeRailItemRef,
-                  hasEndlessScroll: sections.length > 1,
+                  hasEndlessScroll: sections.length > 2,
                 });
               }}
             />

--- a/src/components/EventListComponents/components/RailSections.tsx
+++ b/src/components/EventListComponents/components/RailSections.tsx
@@ -24,7 +24,6 @@ import { TVEventManager } from '@services/tvRCEventListener';
 import debounce from 'lodash.debounce';
 
 type TRailSectionsProps = {
-  horizontalRailOffset: number;
   containerStyle?: ViewProps['style'];
   sections: Array<{ [key: string]: any }>;
   sectionKeyExtractor?: (data: { [key: string]: any }) => string;
@@ -42,7 +41,6 @@ type TRailSectionsProps = {
 
 const RailSections: React.FC<TRailSectionsProps> = props => {
   const {
-    horizontalRailOffset,
     containerStyle = {},
     sections,
     sectionKeyExtractor = data => data.id,
@@ -212,15 +210,6 @@ const RailSections: React.FC<TRailSectionsProps> = props => {
       };
     }, []),
   );
-
-  useEffect(() => {
-    if (mountedRef.current) {
-      railItemsListRef.current?.scrollToOffset({
-        animated: true,
-        offset: horizontalRailOffset * 187.5,
-      });
-    }
-  }, [horizontalRailOffset]);
 
   return (
     <View style={[containerStyle]}>

--- a/src/components/EventListComponents/components/RailSections.tsx
+++ b/src/components/EventListComponents/components/RailSections.tsx
@@ -6,7 +6,6 @@ import React, {
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
-  useEffect,
 } from 'react';
 import {
   View,

--- a/src/screens/BalletDanceScreen/index.tsx
+++ b/src/screens/BalletDanceScreen/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useLayoutEffect } from 'react';
+import React, { useRef, useLayoutEffect, useState } from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import { useSelector } from 'react-redux';
 import { digitalEventsForBalletAndDanceSelector } from '@services/store/events/Selectors';
@@ -34,6 +34,9 @@ const BalletDanceScreen: React.FC<
   const { data, eventsLoaded } = useSelector(
     digitalEventsForBalletAndDanceSelector,
   );
+
+  const [horizontalRailOffset, setHorizontalRailOffset] = useState<number>(0);
+
   const previewRef = useRef<TPreviewRef | null>(null);
   const runningOnceRef = useRef<boolean>(false);
 
@@ -74,9 +77,17 @@ const BalletDanceScreen: React.FC<
         ref={navMenuScreenRedirectRef}
       />
       <View style={styles.contentContainer}>
-        <Preview ref={previewRef} />
+        <Preview
+          ref={component => {
+            if (component?.index && horizontalRailOffset !== component.index) {
+              setHorizontalRailOffset(component.index);
+            }
+            previewRef.current = component;
+          }}
+        />
         <View>
           <RailSections
+            horizontalRailOffset={horizontalRailOffset}
             containerStyle={styles.railContainerStyle}
             headerContainerStyle={styles.railHeaderContainerStyle}
             railStyle={styles.railStyle}
@@ -103,6 +114,7 @@ const BalletDanceScreen: React.FC<
               <DigitalEventItem
                 screenNameFrom={route.name}
                 event={item}
+                eventIndex={index}
                 ref={previewRef}
                 canMoveUp={!isFirstRail}
                 hasTVPreferredFocus={hasTVPreferredFocus(

--- a/src/screens/BalletDanceScreen/index.tsx
+++ b/src/screens/BalletDanceScreen/index.tsx
@@ -35,8 +35,6 @@ const BalletDanceScreen: React.FC<
     digitalEventsForBalletAndDanceSelector,
   );
 
-  const [horizontalRailOffset, setHorizontalRailOffset] = useState<number>(0);
-
   const previewRef = useRef<TPreviewRef | null>(null);
   const runningOnceRef = useRef<boolean>(false);
 
@@ -87,7 +85,6 @@ const BalletDanceScreen: React.FC<
         />
         <View>
           <RailSections
-            horizontalRailOffset={horizontalRailOffset}
             containerStyle={styles.railContainerStyle}
             headerContainerStyle={styles.railHeaderContainerStyle}
             railStyle={styles.railStyle}

--- a/src/screens/BalletDanceScreen/index.tsx
+++ b/src/screens/BalletDanceScreen/index.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useLayoutEffect, useState } from 'react';
-import { View, StyleSheet, Dimensions } from 'react-native';
+import React, { useRef, useLayoutEffect } from 'react';
+import { View, StyleSheet, Dimensions, VirtualizedList } from 'react-native';
 import { useSelector } from 'react-redux';
 import { digitalEventsForBalletAndDanceSelector } from '@services/store/events/Selectors';
 import {
@@ -15,7 +15,6 @@ import {
   marginLeftStop,
 } from '@configs/navMenuConfig';
 import { TPreviewRef } from '@components/EventListComponents/components/Preview';
-import { useIsFocused } from '@react-navigation/native';
 
 import {
   NavMenuScreenRedirect,

--- a/src/screens/BalletDanceScreen/index.tsx
+++ b/src/screens/BalletDanceScreen/index.tsx
@@ -112,14 +112,14 @@ const BalletDanceScreen: React.FC<
                   sectionIndex,
                 )}
                 canMoveRight={index !== section.data.length - 1}
-                onFocus={({ eventIndex }) => {
+                onFocus={({ selectedEventIndex }) => {
                   const railItemsList: VirtualizedList<any> | null =
                     scrollToRail();
 
                   if (railItemsList) {
                     railItemsList.scrollToIndex({
                       animated: true,
-                      index: eventIndex,
+                      index: selectedEventIndex,
                     });
                   }
                 }}

--- a/src/screens/BalletDanceScreen/index.tsx
+++ b/src/screens/BalletDanceScreen/index.tsx
@@ -113,7 +113,17 @@ const BalletDanceScreen: React.FC<
                   sectionIndex,
                 )}
                 canMoveRight={index !== section.data.length - 1}
-                onFocus={scrollToRail}
+                onFocus={({ eventIndex }) => {
+                  const railItemsList: VirtualizedList<any> | null =
+                    scrollToRail();
+
+                  if (railItemsList) {
+                    railItemsList.scrollToIndex({
+                      animated: true,
+                      index: eventIndex,
+                    });
+                  }
+                }}
                 eventGroupTitle={section.title}
                 sectionIndex={sectionIndex}
                 lastItem={index === section.data.length - 1}

--- a/src/screens/BalletDanceScreen/index.tsx
+++ b/src/screens/BalletDanceScreen/index.tsx
@@ -75,14 +75,7 @@ const BalletDanceScreen: React.FC<
         ref={navMenuScreenRedirectRef}
       />
       <View style={styles.contentContainer}>
-        <Preview
-          ref={component => {
-            if (component?.index && horizontalRailOffset !== component.index) {
-              setHorizontalRailOffset(component.index);
-            }
-            previewRef.current = component;
-          }}
-        />
+        <Preview ref={previewRef} />
         <View>
           <RailSections
             containerStyle={styles.railContainerStyle}

--- a/src/screens/HomePageScreen/index.tsx
+++ b/src/screens/HomePageScreen/index.tsx
@@ -152,17 +152,7 @@ const HomePageScreen: React.FC<
       />
       {
         <View>
-          <Preview
-            ref={component => {
-              if (
-                component?.index &&
-                horizontalRailOffset !== component.index
-              ) {
-                setHorizontalRailOffset(component.index);
-              }
-              previewRef.current = component;
-            }}
-          />
+          <Preview ref={previewRef} />
           <View>
             <RailSections
               containerStyle={styles.railContainerStyle}

--- a/src/screens/HomePageScreen/index.tsx
+++ b/src/screens/HomePageScreen/index.tsx
@@ -60,8 +60,6 @@ const HomePageScreen: React.FC<
     digitalEventsForHomePageSelector(myList, continueWatchingList),
   );
 
-  const [horizontalRailOffset, setHorizontalRailOffset] = useState<number>(0);
-
   const previewRef = useRef<TPreviewRef | null>(null);
   const navMenuScreenRedirectRef = useRef<TNavMenuScreenRedirectRef>(null);
   const isFirsRunRef = useRef<boolean>(isFirstRun);
@@ -167,7 +165,6 @@ const HomePageScreen: React.FC<
           />
           <View>
             <RailSections
-              horizontalRailOffset={horizontalRailOffset}
               containerStyle={styles.railContainerStyle}
               headerContainerStyle={styles.railHeaderContainerStyle}
               sectionIndex={route?.params?.sectionIndex || 0}

--- a/src/screens/HomePageScreen/index.tsx
+++ b/src/screens/HomePageScreen/index.tsx
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useEffect,
   useContext,
+  useState,
 } from 'react';
 import {
   View,
@@ -44,6 +45,7 @@ import type {
   NSNavigationScreensNames,
 } from '@configs/screensConfig';
 import { NavMenuNodesRefsContext } from '@components/NavMenu/components/ContextProvider';
+import { TPreviewRef } from 'components/EventListComponents/components/Preview';
 
 const HomePageScreen: React.FC<
   TContentScreensProps<NSNavigationScreensNames.ContentStackScreens['home']>
@@ -57,7 +59,10 @@ const HomePageScreen: React.FC<
   const { data, eventsLoaded } = useAppSelector(
     digitalEventsForHomePageSelector(myList, continueWatchingList),
   );
-  const previewRef = useRef(null);
+
+  const [horizontalRailOffset, setHorizontalRailOffset] = useState<number>(0);
+
+  const previewRef = useRef<TPreviewRef | null>(null);
   const navMenuScreenRedirectRef = useRef<TNavMenuScreenRedirectRef>(null);
   const isFirsRunRef = useRef<boolean>(isFirstRun);
 
@@ -149,9 +154,20 @@ const HomePageScreen: React.FC<
       />
       {
         <View>
-          <Preview ref={previewRef} />
+          <Preview
+            ref={component => {
+              if (
+                component?.index &&
+                horizontalRailOffset !== component.index
+              ) {
+                setHorizontalRailOffset(component.index);
+              }
+              previewRef.current = component;
+            }}
+          />
           <View>
             <RailSections
+              horizontalRailOffset={horizontalRailOffset}
               containerStyle={styles.railContainerStyle}
               headerContainerStyle={styles.railHeaderContainerStyle}
               sectionIndex={route?.params?.sectionIndex || 0}
@@ -177,6 +193,7 @@ const HomePageScreen: React.FC<
               }) => (
                 <DigitalEventItem
                   event={item}
+                  eventIndex={index}
                   ref={previewRef}
                   screenNameFrom={route.name}
                   hasTVPreferredFocus={hasTVPreferredFocus(

--- a/src/screens/HomePageScreen/index.tsx
+++ b/src/screens/HomePageScreen/index.tsx
@@ -1,18 +1,11 @@
-import React, {
-  useRef,
-  useLayoutEffect,
-  useCallback,
-  useEffect,
-  useContext,
-  useState,
-} from 'react';
+import React, { useRef, useLayoutEffect, useEffect, useContext } from 'react';
 import {
   View,
   StyleSheet,
   Dimensions,
   AppState,
   AppStateStatus,
-  findNodeHandle,
+  VirtualizedList,
 } from 'react-native';
 import { useAppSelector, useAppDispatch } from '@hooks/redux';
 import {

--- a/src/screens/HomePageScreen/index.tsx
+++ b/src/screens/HomePageScreen/index.tsx
@@ -189,7 +189,17 @@ const HomePageScreen: React.FC<
                     sectionIndex,
                   )}
                   canMoveRight={index !== section.data.length - 1}
-                  onFocus={scrollToRail}
+                  onFocus={({ eventIndex }) => {
+                    const railItemsList: VirtualizedList<any> | null =
+                      scrollToRail();
+
+                    if (railItemsList) {
+                      railItemsList.scrollToIndex({
+                        animated: true,
+                        index: eventIndex,
+                      });
+                    }
+                  }}
                   continueWatching={section.title === continueWatchingRailTitle}
                   eventGroupTitle={section.title}
                   sectionIndex={sectionIndex}

--- a/src/screens/HomePageScreen/index.tsx
+++ b/src/screens/HomePageScreen/index.tsx
@@ -182,14 +182,14 @@ const HomePageScreen: React.FC<
                     sectionIndex,
                   )}
                   canMoveRight={index !== section.data.length - 1}
-                  onFocus={({ eventIndex }) => {
+                  onFocus={({ selectedEventIndex }) => {
                     const railItemsList: VirtualizedList<any> | null =
                       scrollToRail();
 
                     if (railItemsList) {
                       railItemsList.scrollToIndex({
                         animated: true,
-                        index: eventIndex,
+                        index: selectedEventIndex,
                       });
                     }
                   }}

--- a/src/screens/OperaMusicScreen/index.tsx
+++ b/src/screens/OperaMusicScreen/index.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useLayoutEffect, useState } from 'react';
-import { View, StyleSheet, Dimensions } from 'react-native';
+import React, { useRef, useLayoutEffect } from 'react';
+import { View, StyleSheet, Dimensions, VirtualizedList } from 'react-native';
 import { useSelector } from 'react-redux';
 import { digitalEventsForOperaAndMusicSelector } from '@services/store/events/Selectors';
 import {

--- a/src/screens/OperaMusicScreen/index.tsx
+++ b/src/screens/OperaMusicScreen/index.tsx
@@ -109,14 +109,14 @@ const OperaMusicScreen: React.FC<
                   sectionIndex,
                 )}
                 ref={previewRef}
-                onFocus={({ eventIndex }) => {
+                onFocus={({ selectedEventIndex }) => {
                   const railItemsList: VirtualizedList<any> | null =
                     scrollToRail();
 
                   if (railItemsList) {
                     railItemsList.scrollToIndex({
                       animated: true,
-                      index: eventIndex,
+                      index: selectedEventIndex,
                     });
                   }
                 }}

--- a/src/screens/OperaMusicScreen/index.tsx
+++ b/src/screens/OperaMusicScreen/index.tsx
@@ -73,14 +73,7 @@ const OperaMusicScreen: React.FC<
         ref={navMenuScreenRedirectRef}
       />
       <View style={styles.contentContainer}>
-        <Preview
-          ref={component => {
-            if (component?.index && horizontalRailOffset !== component.index) {
-              setHorizontalRailOffset(component.index);
-            }
-            previewRef.current = component;
-          }}
-        />
+        <Preview ref={previewRef} />
         <View>
           <RailSections
             containerStyle={styles.railContainerStyle}

--- a/src/screens/OperaMusicScreen/index.tsx
+++ b/src/screens/OperaMusicScreen/index.tsx
@@ -109,7 +109,17 @@ const OperaMusicScreen: React.FC<
                   sectionIndex,
                 )}
                 ref={previewRef}
-                onFocus={scrollToRail}
+                onFocus={({ eventIndex }) => {
+                  const railItemsList: VirtualizedList<any> | null =
+                    scrollToRail();
+
+                  if (railItemsList) {
+                    railItemsList.scrollToIndex({
+                      animated: true,
+                      index: eventIndex,
+                    });
+                  }
+                }}
                 canMoveUp={!isFirstRail}
                 canMoveRight={index !== section.data.length - 1}
                 eventGroupTitle={section.title}

--- a/src/screens/OperaMusicScreen/index.tsx
+++ b/src/screens/OperaMusicScreen/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useLayoutEffect } from 'react';
+import React, { useRef, useLayoutEffect, useState } from 'react';
 import { View, StyleSheet, Dimensions } from 'react-native';
 import { useSelector } from 'react-redux';
 import { digitalEventsForOperaAndMusicSelector } from '@services/store/events/Selectors';
@@ -33,6 +33,9 @@ const OperaMusicScreen: React.FC<
   const { data, eventsLoaded } = useSelector(
     digitalEventsForOperaAndMusicSelector,
   );
+
+  const [horizontalRailOffset, setHorizontalRailOffset] = useState<number>(0);
+
   const previewRef = useRef<TPreviewRef | null>(null);
   const runningOnceRef = useRef<boolean>(false);
   const navMenuScreenRedirectRef = useRef<TNavMenuScreenRedirectRef>(null);
@@ -72,9 +75,17 @@ const OperaMusicScreen: React.FC<
         ref={navMenuScreenRedirectRef}
       />
       <View style={styles.contentContainer}>
-        <Preview ref={previewRef} />
+        <Preview
+          ref={component => {
+            if (component?.index && horizontalRailOffset !== component.index) {
+              setHorizontalRailOffset(component.index);
+            }
+            previewRef.current = component;
+          }}
+        />
         <View>
           <RailSections
+            horizontalRailOffset={horizontalRailOffset}
             containerStyle={styles.railContainerStyle}
             headerContainerStyle={styles.railHeaderContainerStyle}
             sectionIndex={route?.params?.sectionIndex || 0}
@@ -101,6 +112,7 @@ const OperaMusicScreen: React.FC<
               <DigitalEventItem
                 screenNameFrom={route.name}
                 event={item}
+                eventIndex={index}
                 hasTVPreferredFocus={hasTVPreferredFocus(
                   isFirstRail,
                   index,

--- a/src/screens/OperaMusicScreen/index.tsx
+++ b/src/screens/OperaMusicScreen/index.tsx
@@ -34,8 +34,6 @@ const OperaMusicScreen: React.FC<
     digitalEventsForOperaAndMusicSelector,
   );
 
-  const [horizontalRailOffset, setHorizontalRailOffset] = useState<number>(0);
-
   const previewRef = useRef<TPreviewRef | null>(null);
   const runningOnceRef = useRef<boolean>(false);
   const navMenuScreenRedirectRef = useRef<TNavMenuScreenRedirectRef>(null);
@@ -85,7 +83,6 @@ const OperaMusicScreen: React.FC<
         />
         <View>
           <RailSections
-            horizontalRailOffset={horizontalRailOffset}
             containerStyle={styles.railContainerStyle}
             headerContainerStyle={styles.railHeaderContainerStyle}
             sectionIndex={route?.params?.sectionIndex || 0}


### PR DESCRIPTION
# Rails with a static highlight
The goal is to achieve the standard behaviour of rail navigation on TVs. In the majority of apps, the focus is kept on the first item of the rail. Instead of moving the focus to the appropriate item, the rail scrolls into place such that said item is within focus.

# Discussion
The implementation is not particularly elegant, since there is a lot of ref-based coupling going on, but, after experimenting with state-based approaches as well, it feels like it has to be this way in order to not affect the performance of the app. For example, when I implemented this mechanic while relying on state, the rail navigation felt quite sluggish.

If you think there is a better way of doing this, please let me know - happy to try new approaches if appropriate :)