### PR TITLE
RD-10201 fix: Replace `_` with `-` in time mark saving for web compat

### DIFF
--- a/src/services/apiClient/index.ts
+++ b/src/services/apiClient/index.ts
@@ -321,7 +321,7 @@ export const getBitMovinPosition = async (
   axiosClient.get<GetWatchStatusResponse>(ApiConfig.routes.watchStatus, {
     params: {
       customerId,
-      videoId: id,
+      videoId: id.replace(/-/g, '_'),
     },
     baseURL: isProductionEnv ? ApiConfig.host : ApiConfig.stagingEnv,
   });
@@ -335,7 +335,7 @@ export const saveBitMovinPosition = (
     ApiConfig.routes.watchStatus,
     {
       customerId,
-      videoId: item.id,
+      videoId: item.id.replace(/_/g, '-'),
       position: item.position,
     },
     {


### PR DESCRIPTION
Due to the discrepancies in video IDs, the time marks from the TV app do not match the ones from the web site. This means that, if a user is watching a video and intends to continue on web (or viceversa), the time marks will not be synchronized.

We should **save** time marks with `-` instead of `_` for web compatibility.
We should **read** time marks with `_` instead of `-` such that they match the `video_key` from Prismic.

Ticket: https://royaloperahouse.atlassian.net/browse/RD-10201